### PR TITLE
Use Call.toString() instead of Call.url() in form tag

### DIFF
--- a/module/app/views/b3/form.scala.html
+++ b/module/app/views/b3/form.scala.html
@@ -1,4 +1,4 @@
 @(action: play.api.mvc.Call, args: (Symbol, Any)*)(body: => Html)(implicit fc: b3.B3FieldConstructor)
-<form action="@action.url" method="@action.method" class="@fc.formClass @Args.get(args, 'class)" @toHtmlArgs(Args.remove(Args.inner(args, 'role -> "form"), 'class).toMap)>
+<form action="@action.toString" method="@action.method" class="@fc.formClass @Args.get(args, 'class)" @toHtmlArgs(Args.remove(Args.inner(args, 'role -> "form"), 'class).toMap)>
 	@body
 </form>


### PR DESCRIPTION
`Call.url()` does not add any `#something` fragment to the url, but `.toString` does.

Checkout these just merged pull requests https://github.com/playframework/playframework/pull/4648 (and https://github.com/playframework/playframework/pull/4670) for explanation.

After Play 2.4.1 is released we can even change the line to use `@action.path`, so we would be in synch with what Play's `@helpers.form` [is using](https://github.com/playframework/playframework/blob/master/framework/src/play/src/main/scala/views/helper/form.scala.html#L17) then. (`.path()` will be available in 2.4.1 but is not in 2.4.0).